### PR TITLE
Enable concurrent order placement

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+# Ensure project root is on sys.path for tests
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# Provide required environment variable for configuration loading during tests
+os.environ.setdefault("IB_ACCOUNT_ID", "TEST")

--- a/tests/test_smart_executor.py
+++ b/tests/test_smart_executor.py
@@ -1,0 +1,55 @@
+import time
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.execution.smart_executor import SmartOrderExecutor, SmartOrder
+from src.core.types import Order, OrderAction, OrderStatus, Trade
+
+
+@pytest.mark.usefixtures("set_ib_account")
+class TestSmartOrderExecutorParallel:
+    def test_parallel_batch_concurrency(self, monkeypatch):
+        """_execute_parallel_batch should run orders concurrently."""
+        ib = MagicMock()
+        pm = MagicMock()
+        config = MagicMock()
+        contracts = {}
+
+        executor = SmartOrderExecutor(ib, pm, config, contracts)
+        executor.max_parallel_orders = 2
+
+        smart_orders = [
+            SmartOrder(Order(symbol=f"SYM{i}", action=OrderAction.BUY, quantity=1))
+            for i in range(4)
+        ]
+
+        def fake_exec(order, timeout):
+            time.sleep(0.2)
+            return Trade(
+                order_id=1,
+                symbol=order.base_order.symbol,
+                action=order.base_order.action,
+                quantity=order.base_order.quantity,
+                fill_price=1.0,
+                commission=0,
+                timestamp=datetime.now(),
+                status=OrderStatus.FILLED,
+            )
+
+        monkeypatch.setattr(executor, "_execute_single_smart_order_with_timeout", fake_exec)
+
+        start = time.time()
+        result = executor._execute_parallel_batch(smart_orders)
+        duration = time.time() - start
+
+        assert duration < 0.6
+        assert len(result.orders_placed) == 4
+        assert not result.orders_failed
+
+
+@pytest.fixture
+def set_ib_account(monkeypatch):
+    monkeypatch.setenv("IB_ACCOUNT_ID", "TEST")
+    yield


### PR DESCRIPTION
## Summary
- run `_execute_parallel_batch` using `ThreadPoolExecutor`
- document concurrent behaviour in `_execute_smart_batches`
- provide test utilities for environment setup
- test new parallel batch logic with mocked orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423ebfe0288330a0cacb052e0e6dce