### PR TITLE
Refactor executors with shared base class

### DIFF
--- a/src/execution/base_executor.py
+++ b/src/execution/base_executor.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from ib_insync import IB, Contract, Trade as IBTrade
+
+from src.config.settings import Config
+from src.core.types import Order, OrderAction, OrderStatus, Trade
+from src.portfolio.manager import PortfolioManager
+from src.utils.logger import get_logger
+
+
+class BaseExecutor:
+    """Common functionality for all order executors."""
+
+    def __init__(
+        self,
+        ib: IB,
+        portfolio_manager: PortfolioManager,
+        config: Config,
+        contracts: Dict[str, Contract],
+    ) -> None:
+        self.ib = ib
+        self.portfolio_manager = portfolio_manager
+        self.config = config
+        self.contracts = contracts
+        self.logger = get_logger(self.__class__.__name__)
+
+    def _create_trade_from_ib(self, ib_trade: IBTrade, order: Optional[Order] = None) -> Trade:
+        """Construct a :class:`Trade` object from an IB trade."""
+        symbol = order.symbol if order else getattr(ib_trade.contract, "symbol", "")
+        action_str = getattr(ib_trade.order, "action", "BUY")
+        action = order.action if order else (OrderAction.BUY if action_str == "BUY" else OrderAction.SELL)
+        quantity = getattr(ib_trade.orderStatus, "filled", 0)
+        avg_price = getattr(ib_trade.orderStatus, "avgFillPrice", 0.0)
+        commission = sum(getattr(fill.commissionReport, "commission", 0) for fill in getattr(ib_trade, "fills", []))
+        status_str = getattr(ib_trade.orderStatus, "status", "Filled")
+        try:
+            status = OrderStatus(status_str)
+        except ValueError:
+            status = OrderStatus.FILLED
+
+        return Trade(
+            order_id=getattr(ib_trade.order, "orderId", 0),
+            symbol=symbol,
+            action=action,
+            quantity=int(quantity),
+            fill_price=float(avg_price),
+            commission=float(commission),
+            timestamp=datetime.now(),
+            status=status,
+        )
+
+    def _validate_fill(self, ib_trade: IBTrade, min_fill_ratio: float) -> bool:
+        """Validate that the fill ratio of an IB trade meets expectations."""
+        try:
+            status = getattr(ib_trade.orderStatus, "status", "")
+            if status in ["Filled", "PartiallyFilled"]:
+                filled_qty = getattr(ib_trade.orderStatus, "filled", 0)
+                total_qty = getattr(ib_trade.order, "totalQuantity", 0)
+                fill_ratio = filled_qty / total_qty if total_qty else 0
+
+                if fill_ratio >= min_fill_ratio:
+                    self.logger.info(
+                        f"Valid fill for {ib_trade.contract.symbol}: {filled_qty}/{total_qty}"
+                    )
+                    return True
+                self.logger.warning(
+                    f"Insufficient fill for {ib_trade.contract.symbol}: {fill_ratio:.1%} < {min_fill_ratio:.1%}"
+                )
+                return False
+
+            self.logger.warning(
+                f"Invalid status for {ib_trade.contract.symbol}: {status}"
+            )
+            return False
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error(f"Fill validation failed: {exc}")
+            return False

--- a/src/execution/batch_executor.py
+++ b/src/execution/batch_executor.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Set, Tuple
 
-from ib_insync import IB, Contract, MarketOrder, LimitOrder, Trade as IBTrade, util
+from ib_insync import IB, Contract, MarketOrder, LimitOrder, Trade as IBTrade
 
 from src.config.settings import Config
 from src.core.exceptions import OrderExecutionError, RetryableError
@@ -17,10 +17,10 @@ from src.core.types import (
     ExecutionResult, Order, OrderAction, OrderStatus, Trade
 )
 from src.portfolio.manager import PortfolioManager
-from src.utils.logger import get_logger
+from .base_executor import BaseExecutor
 
 
-class BatchOrderExecutor:
+class BatchOrderExecutor(BaseExecutor):
     """
     Enhanced batch order executor with true parallel execution.
     
@@ -41,13 +41,9 @@ class BatchOrderExecutor:
         max_parallel_orders: int = 5,
         margin_cushion: float = 0.2
     ):
-        self.ib = ib
-        self.portfolio_manager = portfolio_manager
-        self.config = config
-        self.contracts = contracts
+        super().__init__(ib, portfolio_manager, config, contracts)
         self.max_parallel_orders = max_parallel_orders
         self.margin_cushion = margin_cushion
-        self.logger = get_logger(__name__)
         
         # Execution parameters
         self.order_timeout = 300  # 5 minutes per order
@@ -375,7 +371,7 @@ class BatchOrderExecutor:
             for _ in range(5):
                 if trade.isDone():
                     self.logger.info(f"⚡ Immediate fill detected for {symbol}")
-                    return self._validate_fill(trade)
+                    return self._validate_fill(trade, self.min_fill_ratio)
                 time.sleep(0.1)
             
             # Regular monitoring loop
@@ -383,7 +379,7 @@ class BatchOrderExecutor:
                 try:
                     # Check if order is done
                     if trade.isDone():
-                        return self._validate_fill(trade)
+                        return self._validate_fill(trade, self.min_fill_ratio)
                     
                     # Check for partial fills
                     if trade.orderStatus.filled > 0:
@@ -426,42 +422,6 @@ class BatchOrderExecutor:
             self.logger.error(f"Order monitoring failed for {symbol}: {e}", exc_info=True)
             return False
     
-    def _validate_fill(self, trade: IBTrade) -> bool:
-        """
-        Validate that an order fill is acceptable.
-        
-        Args:
-            trade: IBTrade object to validate
-            
-        Returns:
-            True if fill is valid, False otherwise
-        """
-        try:
-            if trade.orderStatus.status in ['Filled', 'PartiallyFilled']:
-                filled_qty = trade.orderStatus.filled
-                total_qty = trade.order.totalQuantity
-                fill_ratio = filled_qty / total_qty
-                
-                if fill_ratio >= self.min_fill_ratio:
-                    avg_price = trade.orderStatus.avgFillPrice
-                    symbol = trade.contract.symbol
-                    
-                    self.logger.info(
-                        f"✅ Valid fill for {symbol}: {filled_qty}/{total_qty} shares @ ${avg_price:.2f}"
-                    )
-                    return True
-                else:
-                    self.logger.warning(
-                        f"⚠️  Insufficient fill for {trade.contract.symbol}: {fill_ratio:.1%} < {self.min_fill_ratio:.1%}"
-                    )
-                    return False
-            else:
-                self.logger.warning(f"⚠️  Invalid status for {trade.contract.symbol}: {trade.orderStatus.status}")
-                return False
-        
-        except Exception as e:
-            self.logger.error(f"Fill validation failed: {e}")
-            return False
     
     def _compile_results(self, original_orders: List[Order], start_time: float, success: bool) -> ExecutionResult:
         """


### PR DESCRIPTION
## Summary
- factor out trade creation and fill validation into `BaseExecutor`
- inherit all executors from the new base
- use shared helpers in `OrderExecutor`, `BatchOrderExecutor`, and `SmartOrderExecutor`

## Testing
- `make lint` *(fails: The top-level linter settings are deprecated...)*
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842401227b8833092305df7158efd1e