### PR TITLE
Clarify SmartOrderExecutor behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This tool manages leveraged portfolios with:
 - **--hanging-protection**: 5-layer timeout and retry protection
 - **--atomic-margin**: Validate entire batch before execution
 - **Thread-Pool Monitoring**: No hanging on individual order fills
+- **SmartOrderExecutor**: Prioritized batches with thread-pool concurrency
 
 ### 🛡️ Safety Systems
 - **Margin Safety Cushion**: Configurable buffer (default 20%)
@@ -275,6 +276,7 @@ python main.py --batch-execution --smart-orders --hanging-protection --atomic-ma
 - `main.py` - Single canonical entrypoint with feature-based execution
 - `src/strategy/fixed_leverage.py` - Standard fixed leverage strategy
 - `src/strategy/enhanced_fixed_leverage.py` - Advanced batch execution strategy
+- `src/execution/smart_executor.py` - Smart order executor with parallel batches
 - `src/execution/batch_executor.py` - True parallel batch execution
 - `src/portfolio/manager.py` - Portfolio management with safety checks
 - `src/config/portfolio.py` - Default portfolio weights

--- a/main.py
+++ b/main.py
@@ -234,8 +234,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Execution Modes:
-  Standard (default): Sequential order processing, market orders, basic safety
-  Batch: Parallel order processing, smart order types, enhanced safety
+  Standard (default)          : Sequential three-batch processing
+  Smart (--smart-orders etc.) : Parallel batches via SmartOrderExecutor
+  Batch (--batch-execution)   : Fire-all then monitor with thread pools
 
 Key Features:
   --batch-execution    : Process all orders in parallel (faster, production-grade)

--- a/src/execution/smart_executor.py
+++ b/src/execution/smart_executor.py
@@ -1,6 +1,10 @@
 """
-Smart Order Executor with enhanced order management, margin control, and retry logic.
-Addresses production-level issues with market orders, sequential execution, and partial fills.
+Smart Order Executor with enhanced order management, margin control and retry
+logic.
+
+This executor runs orders in prioritized batches. Each batch executes
+concurrently using a small thread pool to avoid hanging while containing risk.
+For full fire-all-then-monitor behaviour see :class:`BatchOrderExecutor`.
 """
 import signal
 import threading
@@ -71,9 +75,12 @@ class MarginCheck:
 
 class SmartOrderExecutor(BaseExecutor):
     """
-    Production-ready order executor with:
+    Production-ready executor using parallel batches and retry logic.
+
+    Features
+    -------
     - Smart order types (Limit, Market, Stop)
-    - Parallel execution within batches
+    - Parallel execution of each batch using ``ThreadPoolExecutor``
     - Retry logic for partial fills
     - Margin control and safety checks
     - Position sizing based on available funds


### PR DESCRIPTION
## Summary
- document SmartOrderExecutor in README
- clarify SmartOrderExecutor usage in CLI help
- update SmartOrderExecutor docstrings

## Testing
- `make test`
- `make lint` *(fails: top-level linter settings deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_684243774b1083308d132cca04a4574a