### PR TITLE
Implement standard wait helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from src.core.types import PortfolioWeight, PortfolioWeights
 from src.strategy.fixed_leverage import FixedLeverageStrategy
 from src.utils.logger import setup_logger
 from src.utils.notifications import TelegramNotifier
+from src.utils.delay import wait
 
 
 # Global watchdog variables
@@ -42,7 +43,7 @@ def setup_watchdog(max_runtime_seconds: int):
     
     def watchdog_timer():
         """Watchdog thread that kills the process if it runs too long."""
-        time.sleep(max_runtime_seconds)
+        wait(max_runtime_seconds)
         if WATCHDOG_ACTIVE:
             print(f"\n🚨 WATCHDOG TIMEOUT: Process exceeded {max_runtime_seconds}s runtime limit!")
             print("🚨 Forcing exit to prevent capital sitting idle...")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -114,4 +114,3 @@ if __name__ == "__main__":
     if not env_example_path.exists():
         with open(env_example_path, "w") as f:
             f.write(ENV_TEMPLATE)
-        print(f"Created {env_example_path}") 

--- a/src/data/market_data.py
+++ b/src/data/market_data.py
@@ -12,6 +12,7 @@ from ib_insync import IB, Contract, Forex, Stock, MarketOrder
 from src.core.exceptions import MarketDataError, TemporaryError
 from src.core.types import MarketData
 from src.utils.logger import get_logger
+from src.utils.delay import wait
 
 
 class MarketDataManager:
@@ -75,7 +76,7 @@ class MarketDataManager:
             timeout = 10
             
             while time.time() - start_time < timeout:
-                self.ib.sleep(0.5)
+                wait(0.5, self.ib)
                 
                 # Try midpoint first
                 if ticker.midpoint() and ticker.midpoint() > 0:
@@ -135,7 +136,7 @@ class MarketDataManager:
             start_time = time.time()
             
             while time.time() - start_time < timeout:
-                self.ib.sleep(0.5)
+                wait(0.5, self.ib)
                 
                 market_data = MarketData(
                     symbol=symbol,
@@ -192,7 +193,7 @@ class MarketDataManager:
                 tickers.append((contract.symbol, ticker))
             
             # Wait for data
-            self.ib.sleep(2)
+            wait(2, self.ib)
             
             # Collect prices
             for symbol, ticker in tickers:

--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -18,6 +18,7 @@ from src.core.types import (
 )
 from src.portfolio.manager import PortfolioManager
 from src.utils.logger import get_logger
+from src.utils.delay import wait
 
 
 class OrderExecutor:
@@ -178,7 +179,7 @@ class OrderExecutor:
             
             # Wait between batches
             if batch_idx < len(batches) - 1:
-                time.sleep(self.batch_delay)
+                wait(self.batch_delay, self.ib)
             
             # Check leverage after each batch
             try:
@@ -255,7 +256,7 @@ class OrderExecutor:
                             f"Retryable error for {order.symbol}, attempt {attempt + 1}/{self.max_retries}",
                             error=str(e)
                         )
-                        time.sleep(2 ** attempt)  # Exponential backoff
+                        wait(2 ** attempt, self.ib)  # Exponential backoff
                     else:
                         failed.append(order)
                         errors.append(f"{order.symbol}: {str(e)}")
@@ -295,7 +296,7 @@ class OrderExecutor:
         start_time = time.time()
         
         while time.time() - start_time < timeout:
-            self.ib.sleep(0.5)
+            wait(0.5, self.ib)
             
             if ib_trade.isDone():
                 # Order completed

--- a/src/portfolio/manager.py
+++ b/src/portfolio/manager.py
@@ -20,6 +20,7 @@ from src.core.types import (
 )
 from src.data.market_data import MarketDataManager
 from src.utils.logger import get_logger
+from src.utils.delay import wait
 
 
 class PortfolioManager:
@@ -380,7 +381,7 @@ class PortfolioManager:
                     # Wait for fill with shorter timeout
                     filled = False
                     for _ in range(30):  # 30 second timeout
-                        self.ib.sleep(1)
+                        wait(1, self.ib)
                         if trade.isDone():
                             filled = True
                             break

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,3 @@
+from .delay import wait
+
+__all__ = ["wait"]

--- a/src/utils/delay.py
+++ b/src/utils/delay.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Utility for standardized sleep/delay handling."""
+from time import sleep as time_sleep
+from typing import Optional
+
+from ib_insync import IB
+
+
+def wait(seconds: float, ib: Optional[IB] = None) -> None:
+    """Pause execution for the given number of seconds."""
+    if ib is not None:
+        ib.sleep(seconds)
+    else:
+        time_sleep(seconds)


### PR DESCRIPTION
## Summary
- add utility wait() wrapper for IB sleep handling
- use wait() across executor modules and main
- clean up obsolete print in settings

## Testing
- `make lint` *(fails: Found 315 errors)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6842401366708330be7ded4265d2e997