### PR TITLE
Check managed accounts on connect

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 from src.config.portfolio import get_default_portfolio
 from src.config.settings import load_config
 from src.core.connection import create_connection_manager
+from src.core.exceptions import ConnectionError
 from src.core.types import PortfolioWeight, PortfolioWeights
 from src.strategy.fixed_leverage import FixedLeverageStrategy
 from src.utils.delay import wait
@@ -514,6 +515,23 @@ Examples:
             print("Interrupted by user")
         disable_watchdog()
         return 0
+    except ConnectionError as e:
+        banner = "\n" + "!" * 60
+        banner += "\n⚠️  Connection error: Possible competing session detected\n"
+        banner += "!" * 60
+        print(banner)
+        if logger:
+            logger.error(f"Error: {e}", exc_info=True)
+        else:
+            print(f"Error: {e}")
+            import traceback
+
+            traceback.print_exc()
+        if telegram:
+            telegram.send_message(f"❌ Error during rebalancing: {str(e)}")
+
+        disable_watchdog()
+        return 2
     except Exception as e:
         if logger:
             logger.error(f"Error: {e}", exc_info=True)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -40,7 +40,7 @@ class IBConfig:
 
     host: str = field(default_factory=lambda: os.getenv("IB_GATEWAY_HOST", "127.0.0.1"))
     port: int = field(default_factory=lambda: int(os.getenv("IB_GATEWAY_PORT", "4002")))
-    client_id: int = field(default_factory=lambda: int(os.getenv("IB_CLIENT_ID", "1")))
+    client_id: int = field(default_factory=lambda: int(os.getenv("IB_CLIENT_ID", "0")))
     account_id: Optional[str] = field(default_factory=lambda: os.getenv("IB_ACCOUNT_ID"))
 
 

--- a/src/core/connection.py
+++ b/src/core/connection.py
@@ -55,6 +55,19 @@ class IBConnectionManager:
                     timeout=timeout,
                 )
 
+                accounts = self.ib.managedAccounts()
+                if not accounts:
+                    self.logger.critical(
+                        "Connected but no managed accounts returned",
+                        host=self.config.host,
+                        port=self.config.port,
+                        client_id=self.config.client_id,
+                    )
+                    self._cleanup()
+                    raise ConnectionError(
+                        "No managed accounts returned - possible competing session"
+                    )
+
                 connection_time = time.time() - start_time
                 self._is_connected = True
 
@@ -189,6 +202,19 @@ class AsyncIBConnectionManager(IBConnectionManager):
                     clientId=self.config.client_id,
                     timeout=timeout,
                 )
+
+                accounts = self.ib.managedAccounts()
+                if not accounts:
+                    self.logger.critical(
+                        "Connected but no managed accounts returned",
+                        host=self.config.host,
+                        port=self.config.port,
+                        client_id=self.config.client_id,
+                    )
+                    await self._cleanup_async()
+                    raise ConnectionError(
+                        "No managed accounts returned - possible competing session"
+                    )
 
                 self._is_connected = True
                 self._loop = asyncio.get_event_loop()

--- a/src/execution/batch_executor.py
+++ b/src/execution/batch_executor.py
@@ -481,13 +481,12 @@ class BatchOrderExecutor(BaseExecutor):
                         symbol=symbol,
                         action=original_order.action,
                         quantity=trade.orderStatus.filled,
-
-                        price=trade.orderStatus.avgFillPrice or 0,
+                        fill_price=trade.orderStatus.avgFillPrice or 0,
                         commission=(
                             trade.commissionReport.commission if trade.commissionReport else 0
                         ),
                         timestamp=datetime.now(),
-
+                        status=OrderStatus.FILLED,
                     )
                     successful_trades.append(trade_obj)
 

--- a/tests/mock_gateway.py
+++ b/tests/mock_gateway.py
@@ -85,3 +85,6 @@ class MockIBGateway:
 
     def isConnected(self) -> bool:
         return True
+
+    def managedAccounts(self) -> List[str]:  # pragma: no cover - simple list
+        return ["TEST"]

--- a/tests/test_connection_edgecases.py
+++ b/tests/test_connection_edgecases.py
@@ -65,3 +65,20 @@ def test_connect_success_and_disconnect(monkeypatch):
 
     manager.disconnect()
     fake_ib.disconnect.assert_called_once()
+
+
+def test_connect_managed_accounts_empty(monkeypatch):
+    fake_ib = MagicMock()
+    fake_ib.isConnected.return_value = True
+    fake_ib.connect.return_value = None
+    fake_ib.managedAccounts.return_value = []
+    fake_ib.disconnect.return_value = None
+    monkeypatch.setattr("src.core.connection.IB", lambda: fake_ib)
+
+    config = MagicMock(host="h", port=1, client_id=2, account_id="A")
+    manager = IBConnectionManager(config)
+
+    with pytest.raises(ConnectionError):
+        manager.connect()
+
+    assert fake_ib.managedAccounts.call_count >= 1

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -30,6 +30,9 @@ def test_connection_retry_backoff(monkeypatch):
             if len(attempts) < 3:
                 raise RuntimeError("fail")
 
+        def managedAccounts(self):
+            return ["TEST"]
+
         def isConnected(self):
             return True
 

--- a/tests/test_manager_edgecases.py
+++ b/tests/test_manager_edgecases.py
@@ -23,6 +23,7 @@ def manager_instance():
     market_data = MagicMock()
     config = MagicMock()
     config.ib.account_id = "TEST"
+    config.accounts = []
     contracts = {"AAPL": MagicMock()}
     pm = PortfolioManager(ib, market_data, config, contracts)
     return pm, ib, market_data


### PR DESCRIPTION
## Summary
- default to client_id 0
- verify managed accounts after connecting
- show warning banner if account list empty
- fix batch executor trade result
- update mock gateway and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473eaab6108330b7e055845998231d