### PR TITLE
Switch executors to waitOnUpdate

### DIFF
--- a/src/execution/batch_executor.py
+++ b/src/execution/batch_executor.py
@@ -3,22 +3,18 @@ Enhanced batch order executor with atomic margin checks and fire-all-then-monito
 Addresses P0-A and P0-D: true batch execution with atomic margin validation.
 """
 
-import asyncio
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Set, Tuple
+from datetime import datetime
+from typing import Dict, List
 
 from ib_insync import IB, Contract, LimitOrder, MarketOrder
 from ib_insync import Trade as IBTrade
 
 from src.config.settings import Config
-from src.core.exceptions import OrderExecutionError, RetryableError
 from src.core.types import ExecutionResult, Order, OrderAction, OrderStatus, Trade
 from src.portfolio.manager import PortfolioManager
 from src.utils.delay import wait
-from src.utils.logger import get_logger
 
 from .base_executor import BaseExecutor
 
@@ -149,7 +145,7 @@ class BatchOrderExecutor(BaseExecutor):
                         ticker = self.ib.reqMktData(contract, "", False, False)
 
                         # Keep IB event loop active while waiting for price
-                        self.ib.sleep(0.1)
+                        wait(0.1, self.ib)
 
                         price = ticker.marketPrice()
                         if price and price > 0:
@@ -256,7 +252,7 @@ class BatchOrderExecutor(BaseExecutor):
         ticker = self.ib.reqMktData(contract, "", False, False)
 
         # Allow the event loop to process data while waiting
-        self.ib.sleep(0.1)
+        wait(0.1, self.ib)
 
         market_price = ticker.marketPrice()
         order_value = market_price * order.quantity if market_price else 0
@@ -340,7 +336,6 @@ class BatchOrderExecutor(BaseExecutor):
 
                 # Check progress
                 elapsed_time = time.time() - start_time
-                remaining_orders = len(ib_trades) - completed_count - len(self.failed_orders)
 
                 if elapsed_time > self.batch_timeout:
                     self.logger.warning(
@@ -390,7 +385,7 @@ class BatchOrderExecutor(BaseExecutor):
                     return self._validate_fill(trade, self.min_fill_ratio)
 
                 # Keep event loop alive during quick checks
-                self.ib.sleep(0.1)
+                wait(0.1, self.ib)
 
             # Regular monitoring loop
             while time.time() - start_time < self.order_timeout and self._monitor_active:
@@ -412,12 +407,12 @@ class BatchOrderExecutor(BaseExecutor):
                             return True
 
                     # Brief sleep to prevent busy waiting while keeping IB responsive
-                    self.ib.sleep(0.5)
+                    wait(0.5, self.ib)
 
                 except Exception as e:
                     self.logger.warning(f"Monitoring error for {symbol}: {e}")
                     # Longer pause on errors without blocking event loop
-                    self.ib.sleep(1)
+                    wait(1, self.ib)
 
             # Timeout reached
             self.logger.warning(f"⏰ Order timeout for {symbol} after {self.order_timeout}s")
@@ -427,7 +422,7 @@ class BatchOrderExecutor(BaseExecutor):
                 self.ib.cancelOrder(trade.order)
 
                 # Give IB time to process cancellation
-                self.ib.sleep(1)
+                wait(1, self.ib)
 
                 # Check final fill status
                 if trade.orderStatus.filled > 0:
@@ -468,7 +463,7 @@ class BatchOrderExecutor(BaseExecutor):
         successful_trades = []
         failed_orders = []
 
-        for order_id, trade in self.completed_orders.items():
+        for _order_id, trade in self.completed_orders.items():
             try:
                 # Create Trade object
                 symbol = trade.contract.symbol
@@ -476,18 +471,22 @@ class BatchOrderExecutor(BaseExecutor):
                 # Find original order
                 original_order = next((o for o in original_orders if o.symbol == symbol), None)
                 if original_order:
+                    status_str = getattr(trade.orderStatus, "status", "Filled")
+                    try:
+                        status = OrderStatus(status_str)
+                    except Exception:
+                        status = OrderStatus.FILLED
                     trade_obj = Trade(
                         order_id=trade.order.orderId,
                         symbol=symbol,
                         action=original_order.action,
                         quantity=trade.orderStatus.filled,
-
-                        price=trade.orderStatus.avgFillPrice or 0,
+                        fill_price=trade.orderStatus.avgFillPrice or 0,
                         commission=(
                             trade.commissionReport.commission if trade.commissionReport else 0
                         ),
                         timestamp=datetime.now(),
-
+                        status=status,
                     )
                     successful_trades.append(trade_obj)
 

--- a/src/execution/smart_executor.py
+++ b/src/execution/smart_executor.py
@@ -1,4 +1,3 @@
-
 """Smart Order Executor with enhanced order management, margin control and
 parallel batch execution.
 
@@ -106,7 +105,6 @@ class SmartOrderExecutor(BaseExecutor):
         config: Config,
         contracts: Dict[str, Contract],
     ):
-
         super().__init__(ib, portfolio_manager, config, contracts)
 
         # Execution parameters
@@ -229,7 +227,6 @@ class SmartOrderExecutor(BaseExecutor):
                     # Get current market price
                     contract = self.contracts.get(symbol)
                     if contract:
-
                         ticker = self.ib.reqMktData(contract, "", False, False)
 
                         wait(1, self.ib)  # Wait for price
@@ -466,7 +463,6 @@ class SmartOrderExecutor(BaseExecutor):
 
             # Brief pause between batches
             if batch_idx < len(batches) - 1:
-
                 wait(2, self.ib)
 
             # Monitor leverage after each batch
@@ -733,8 +729,7 @@ class SmartOrderExecutor(BaseExecutor):
         stall_threshold = 10  # Time without status change before refresh
 
         for quick_check in range(max_immediate_checks):
-
-            self.ib.sleep(0.1)  # Very brief pause
+            wait(0.1, self.ib)  # Very brief pause
 
             # Refresh connection if no status update
             if (
@@ -764,8 +759,7 @@ class SmartOrderExecutor(BaseExecutor):
 
         # If not immediately filled, do regular monitoring with timeout
         while time.time() - start_time < timeout_seconds:
-
-            self.ib.sleep(check_interval)
+            wait(check_interval, self.ib)
 
             # Refresh connection if status hasn't changed
             if (
@@ -885,9 +879,8 @@ class SmartOrderExecutor(BaseExecutor):
                 self.logger.warning(f"Invalid fill price for {symbol}: {avg_price}")
                 # Try to get a reasonable price estimate
                 try:
-
                     ticker = self.ib.reqMktData(ib_trade.contract, "", False, False)
-                    self.ib.sleep(0.5)
+                    wait(0.5, self.ib)
 
                     if ticker.last and ticker.last > 0:
                         avg_price = ticker.last

--- a/src/utils/delay.py
+++ b/src/utils/delay.py
@@ -1,15 +1,19 @@
+"""Utility for standardized sleep/delay handling."""
+
 from __future__ import annotations
 
-"""Utility for standardized sleep/delay handling."""
 from time import sleep as time_sleep
-from typing import Optional
 
 from ib_insync import IB
 
 
-def wait(seconds: float, ib: Optional[IB] = None) -> None:
+def wait(seconds: float, ib: IB | None = None) -> None:
     """Pause execution for the given number of seconds."""
     if ib is not None:
-        ib.sleep(seconds)
+        wait_fn = getattr(ib, "waitOnUpdate", getattr(ib, "sleep", None))
+        if wait_fn is not None:
+            wait_fn(seconds)
+        else:  # pragma: no cover - extremely unlikely
+            time_sleep(seconds)
     else:
         time_sleep(seconds)

--- a/tests/test_manager_edgecases.py
+++ b/tests/test_manager_edgecases.py
@@ -23,6 +23,7 @@ def manager_instance():
     market_data = MagicMock()
     config = MagicMock()
     config.ib.account_id = "TEST"
+    config.accounts = []
     contracts = {"AAPL": MagicMock()}
     pm = PortfolioManager(ib, market_data, config, contracts)
     return pm, ib, market_data
@@ -66,6 +67,7 @@ def test_get_portfolio_leverage_conversion(manager_instance):
     leverage = pm.get_portfolio_leverage()
 
     assert leverage == 2.0
+
 
 def test_get_portfolio_leverage_zero_nlv(manager_instance):
     pm, _, md = manager_instance


### PR DESCRIPTION
## Summary
- make `wait` use `waitOnUpdate` if available
- replace direct `ib.sleep` calls with `wait`
- patch unit tests to stub `wait`
- add regression test running `_monitor_single_order` in a thread
- adjust manager edge case fixture

## Testing
- `ruff check src/utils/delay.py src/execution/batch_executor.py src/execution/smart_executor.py tests/test_batch_executor_edgecases.py tests/test_manager_edgecases.py`
- `black src/execution/batch_executor.py src/utils/delay.py src/execution/smart_executor.py tests/test_batch_executor_edgecases.py tests/test_manager_edgecases.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473ea4924c83308f051c6d1885e940