### PR TITLE
Fix wait logic using IB.waitOnUpdate

### DIFF
--- a/src/execution/smart_executor.py
+++ b/src/execution/smart_executor.py
@@ -1,4 +1,3 @@
-
 """Smart Order Executor with enhanced order management, margin control and
 parallel batch execution.
 
@@ -734,7 +733,7 @@ class SmartOrderExecutor(BaseExecutor):
 
         for quick_check in range(max_immediate_checks):
 
-            self.ib.sleep(0.1)  # Very brief pause
+            wait(0.1, self.ib)  # Very brief pause
 
             # Refresh connection if no status update
             if (
@@ -765,7 +764,7 @@ class SmartOrderExecutor(BaseExecutor):
         # If not immediately filled, do regular monitoring with timeout
         while time.time() - start_time < timeout_seconds:
 
-            self.ib.sleep(check_interval)
+            wait(check_interval, self.ib)
 
             # Refresh connection if status hasn't changed
             if (
@@ -887,7 +886,7 @@ class SmartOrderExecutor(BaseExecutor):
                 try:
 
                     ticker = self.ib.reqMktData(ib_trade.contract, "", False, False)
-                    self.ib.sleep(0.5)
+                    wait(0.5, self.ib)
 
                     if ticker.last and ticker.last > 0:
                         avg_price = ticker.last

--- a/src/utils/delay.py
+++ b/src/utils/delay.py
@@ -1,15 +1,25 @@
+"""Utility for standardized sleep/delay handling."""
+
 from __future__ import annotations
 
-"""Utility for standardized sleep/delay handling."""
 from time import sleep as time_sleep
-from typing import Optional
 
 from ib_insync import IB
 
 
-def wait(seconds: float, ib: Optional[IB] = None) -> None:
-    """Pause execution for the given number of seconds."""
+def wait(seconds: float, ib: IB | None = None) -> None:
+    """Pause execution for the given number of seconds.
+
+    When an ``IB`` instance is provided, use its non-blocking wait
+    mechanism to keep the event loop responsive. Fallbacks to ``sleep``
+    if ``waitOnUpdate`` is unavailable.
+    """
     if ib is not None:
-        ib.sleep(seconds)
+        if hasattr(ib, "waitOnUpdate"):
+            ib.waitOnUpdate(seconds)
+        elif hasattr(ib, "sleep"):
+            ib.sleep(seconds)
+        else:
+            time_sleep(seconds)
     else:
         time_sleep(seconds)

--- a/tests/test_batch_executor_edgecases.py
+++ b/tests/test_batch_executor_edgecases.py
@@ -1,10 +1,10 @@
 import time
-from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import pytest
 
-from src.core.types import Order, OrderAction, OrderStatus, Trade
+from src.core.types import Order, OrderAction
 from src.execution.batch_executor import BatchOrderExecutor
 
 
@@ -24,13 +24,13 @@ def make_ticker(price):
     return ticker
 
 
-def test_check_batch_margin_safety_insufficient_funds(simple_executor):
+def test_check_batch_margin_safety_insufficient_funds(simple_executor, monkeypatch):
     executor, ib, pm = simple_executor
     order = Order(symbol="AAPL", action=OrderAction.BUY, quantity=10)
     pm.get_account_summary.return_value = {"AvailableFunds": 1000, "NetLiquidation": 2000}
     pm.get_positions.return_value = {}
     ib.reqMktData.return_value = make_ticker(100)
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
 
     result = executor._check_batch_margin_safety([order])
 
@@ -38,10 +38,10 @@ def test_check_batch_margin_safety_insufficient_funds(simple_executor):
     ib.cancelMktData.assert_called_once_with(executor.contracts["AAPL"])
 
 
-def test_create_smart_order_types(simple_executor):
+def test_create_smart_order_types(simple_executor, monkeypatch):
     executor, ib, pm = simple_executor
     ib.reqMktData.return_value = make_ticker(200)
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
 
     small_order = Order(symbol="AAPL", action=OrderAction.BUY, quantity=10)
     big_order = Order(symbol="AAPL", action=OrderAction.SELL, quantity=100)
@@ -49,7 +49,7 @@ def test_create_smart_order_types(simple_executor):
     mo = executor._create_smart_order(small_order)
     lo = executor._create_smart_order(big_order)
 
-    from ib_insync import MarketOrder, LimitOrder
+    from ib_insync import LimitOrder, MarketOrder
 
     assert isinstance(mo, MarketOrder)
     assert isinstance(lo, LimitOrder)
@@ -91,6 +91,7 @@ def test_compile_results_builds_trades(simple_executor, monkeypatch):
     assert res.total_commission == 1.0
     assert "boom" in res.errors[0]
 
+
 def test_monitor_single_order_immediate_fill(simple_executor, monkeypatch):
     executor, ib, pm = simple_executor
     trade = MagicMock()
@@ -100,7 +101,7 @@ def test_monitor_single_order_immediate_fill(simple_executor, monkeypatch):
     trade.order.totalQuantity = 10
     trade.orderStatus.avgFillPrice = 100
     trade.isDone.return_value = True
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
     monkeypatch.setattr(executor, "_validate_fill", lambda *args, **kwargs: True)
     assert executor._monitor_single_order(trade)
 
@@ -119,11 +120,12 @@ def test_cleanup_monitoring(simple_executor):
     assert executor.failed_orders == {}
     dummy_exec.shutdown.assert_called()
 
-def test_fire_all_orders_places_orders(simple_executor):
+
+def test_fire_all_orders_places_orders(simple_executor, monkeypatch):
     executor, ib, pm = simple_executor
     ib.placeOrder.return_value = MagicMock()
     ib.reqMktData.return_value = make_ticker(50)
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
     order = Order(symbol="AAPL", action=OrderAction.BUY, quantity=1)
     result = executor._fire_all_orders([order])
     assert len(result) == 1
@@ -153,17 +155,20 @@ def test_monitor_all_orders_success(simple_executor, monkeypatch):
     monkeypatch.setattr("src.execution.batch_executor.ThreadPoolExecutor", DummyExecutor)
     monkeypatch.setattr("src.execution.batch_executor.as_completed", lambda fs, timeout=None: fs)
     monkeypatch.setattr(executor, "_monitor_single_order", lambda t: True)
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
 
     assert executor._monitor_all_orders([trade])
 
-def test_check_batch_margin_safety_success(simple_executor):
+
+def test_check_batch_margin_safety_success(simple_executor, monkeypatch):
     executor, ib, pm = simple_executor
     order = Order(symbol="AAPL", action=OrderAction.BUY, quantity=1)
     pm.get_account_summary.return_value = {"AvailableFunds": 100000, "NetLiquidation": 200000}
     pm.get_positions.return_value = {}
     ib.reqMktData.return_value = make_ticker(50)
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
     assert executor._check_batch_margin_safety([order])
+
 
 def test_monitor_single_order_partial_fill(simple_executor, monkeypatch):
     executor, ib, _ = simple_executor
@@ -174,6 +179,27 @@ def test_monitor_single_order_partial_fill(simple_executor, monkeypatch):
     trade.orderStatus.filled = 5
     trade.orderStatus.avgFillPrice = 50
     trade.isDone.side_effect = [False, False, True]
-    executor.ib.sleep = lambda *_: None
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
     monkeypatch.setattr(executor, "_validate_fill", lambda *args, **kwargs: True)
     assert executor._monitor_single_order(trade)
+
+
+def test_monitor_single_order_thread_safe(simple_executor, monkeypatch):
+    """Ensure _monitor_single_order can run in a background thread."""
+    executor, ib, _ = simple_executor
+    trade = MagicMock()
+    trade.order.orderId = 1
+    trade.contract.symbol = "AAPL"
+    trade.order.totalQuantity = 1
+    trade.orderStatus.filled = 1
+    trade.orderStatus.avgFillPrice = 100
+    trade.isDone.return_value = True
+
+    monkeypatch.setattr("src.utils.delay.wait", lambda *_: None)
+    monkeypatch.setattr(executor, "_validate_fill", lambda *a, **k: True)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(executor._monitor_single_order, trade)
+        result = future.result()
+
+    assert result

--- a/tests/test_manager_edgecases.py
+++ b/tests/test_manager_edgecases.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.core.types import OrderAction, Position
+from src.core.types import Position
 from src.portfolio.manager import PortfolioManager
 
 
@@ -67,6 +67,7 @@ def test_get_portfolio_leverage_conversion(manager_instance):
     leverage = pm.get_portfolio_leverage()
 
     assert leverage == 2.0
+
 
 def test_get_portfolio_leverage_zero_nlv(manager_instance):
     pm, _, md = manager_instance


### PR DESCRIPTION
## Summary
- use IB.waitOnUpdate in `wait`
- replace direct `ib.sleep` calls with `wait`
- adjust tests to patch `src.utils.delay.wait`
- ensure `_monitor_single_order` runs safely in threads
- minor lint fixes

## Testing
- `ruff check src/utils/delay.py src/execution/batch_executor.py src/execution/smart_executor.py tests/test_batch_executor_edgecases.py tests/test_manager_edgecases.py`
- `black src/execution/batch_executor.py src/utils/delay.py src/execution/smart_executor.py tests/test_batch_executor_edgecases.py tests/test_manager_edgecases.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684741f4a7d08330bb66a61dbe1db663