### PR TITLE
Fix README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@ Before going live:
 ## Advanced Usage
 
 See [docs/](docs/) for:
-- [Interactive Brokers Setup Guide](docs/IB_SETUP.md)
-- [Advanced Configuration](docs/CONFIGURATION.md)
-- [API Reference](docs/API.md)
+- [Interactive Brokers Setup Guide](docs/INTERACTIVE_BROKERS_SETUP.md)
+- [IB API Best Practices](docs/IB_API_BEST_PRACTICES.md)
+- [Portfolio Rebalancing Strategies](docs/PORTFOLIO_REBALANCING_STRATEGIES.md)
+- [Migration Guide](docs/MIGRATION.md)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- point README links to the right files in `docs/`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68474e4205f88330840d81660e0f9804